### PR TITLE
refs #21 iPhoneで特定BGM組み合わせ時にゲーム途中でリロードされる

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ kuku/
     ├── free-select.js  # 自由選択モード
     ├── table.js        # 九九の表モード・読み上げ再生
     ├── audio.js        # BGM 管理・曲切り替え
-    ├── tone-engines.js # Tone.js エンジン（ノリノリ・わくわく、iPhone向け軽量構成）
+    ├── tone-engines.js # Tone.js エンジン（ノリノリ・わくわく、軽量構成）
     ├── se.js           # 効果音（playSe）
     └── init.js         # 起動時初期化 IIFE
 ```

--- a/css/base.css
+++ b/css/base.css
@@ -44,7 +44,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  animation: dreamySky 6s ease-in-out infinite;
+  background-position: 42% 50%;
 }
 
 #app {
@@ -70,10 +70,8 @@ body {
   pointer-events: none;
   background:
     conic-gradient(from 40deg, rgba(255, 47, 168, 0.32), rgba(34, 217, 255, 0.32), rgba(168, 240, 79, 0.28), rgba(255, 215, 0, 0.34), rgba(255, 47, 168, 0.32));
-  filter: blur(24px) saturate(1.4);
-  opacity: 1;
-  animation: colorSpin 8s linear infinite;
-  mix-blend-mode: screen;
+  filter: blur(10px);
+  opacity: 0.55;
 }
 
 #app::after {
@@ -85,7 +83,7 @@ body {
   background:
     repeating-linear-gradient(45deg, transparent 0 14px, rgba(255,255,255,0.04) 14px 16px),
     radial-gradient(ellipse at center, transparent 40%, rgba(59, 36, 124, 0.18) 100%);
-  animation: vignettePulse 3.6s ease-in-out infinite;
+  opacity: 0.72;
 }
 
 @keyframes vignettePulse {
@@ -100,7 +98,6 @@ body {
   pointer-events: none;
   z-index: 80;
   opacity: 0;
-  mix-blend-mode: screen;
 }
 
 .screen-flash.active {
@@ -116,9 +113,8 @@ body {
 }
 
 .screen-flash.fever {
-  background:
-    conic-gradient(from 0deg, #ff2fa8, #ffd700, #4ecdc4, #65d6ff, #a8f04f, #ff2fa8);
-  animation: feverFlash 1.1s ease-out forwards;
+  background: radial-gradient(circle at center, rgba(255, 215, 0, 0.78), rgba(255, 47, 168, 0.42), transparent 72%);
+  animation: feverFlash 0.8s ease-out forwards;
 }
 
 @keyframes screenFlash {
@@ -128,9 +124,9 @@ body {
 }
 
 @keyframes feverFlash {
-  0% { opacity: 0; transform: rotate(0deg) scale(0.5); filter: blur(18px); }
-  40% { opacity: 0.85; transform: rotate(120deg) scale(1.2); filter: blur(8px); }
-  100% { opacity: 0; transform: rotate(360deg) scale(1.8); filter: blur(28px); }
+  0% { opacity: 0; transform: scale(0.6); }
+  40% { opacity: 0.72; transform: scale(1.12); }
+  100% { opacity: 0; transform: scale(1.45); }
 }
 
 /* 全画面シェイク */
@@ -178,9 +174,8 @@ body {
   background: linear-gradient(to bottom, transparent, var(--laser-color), transparent);
   transform-origin: top center;
   transform: translate(-50%, 0) rotate(var(--angle));
-  filter: drop-shadow(0 0 10px var(--laser-color));
   pointer-events: none;
-  animation: laserShoot 0.7s ease-out forwards;
+  animation: laserShoot 0.6s ease-out forwards;
 }
 
 @keyframes laserShoot {
@@ -217,7 +212,7 @@ body {
   height: 4px;
   border-radius: 50%;
   background: white;
-  box-shadow: 0 0 12px white, 0 0 24px var(--ssc);
+  box-shadow: 0 0 10px var(--ssc);
   pointer-events: none;
   animation: shootStar 1.4s linear forwards;
 }
@@ -260,8 +255,7 @@ body {
   border-right-color: rgba(78, 205, 196, 0.32);
   border-radius: 50%;
   transform: translateX(-50%) rotateX(58deg) rotateZ(-12deg);
-  filter: drop-shadow(0 0 22px rgba(255, 255, 255, 0.65));
-  animation: ribbonRoll 7s ease-in-out infinite;
+  opacity: 0.74;
 }
 
 .warp-grid {
@@ -277,8 +271,7 @@ body {
   transform: rotateX(64deg) translateZ(-60px);
   transform-origin: center bottom;
   opacity: 0.7;
-  filter: drop-shadow(0 0 12px rgba(255, 47, 168, 0.5));
-  animation: gridRun 0.8s linear infinite;
+  opacity: 0.52;
 }
 
 .warp-grid::after {
@@ -286,8 +279,7 @@ body {
   position: absolute;
   inset: 0;
   background: linear-gradient(to top, rgba(255, 215, 0, 0.35), transparent 60%);
-  mix-blend-mode: screen;
-  animation: gridGlow 2.5s ease-in-out infinite;
+  opacity: 0.55;
 }
 
 @keyframes gridGlow {
@@ -309,7 +301,7 @@ body {
   font-size: 1.1rem;
   font-weight: 900;
   text-shadow: 0 2px 0 rgba(59, 36, 124, 0.38), 0 0 14px rgba(255,255,255,0.9);
-  box-shadow: 0 16px 32px rgba(59, 36, 124, 0.18), 0 0 26px rgba(255,105,180,0.36), inset 0 0 0 2px rgba(255,255,255,0.62);
+  box-shadow: 0 10px 20px rgba(59, 36, 124, 0.14), 0 0 14px rgba(255,105,180,0.24), inset 0 0 0 2px rgba(255,255,255,0.62);
   transform-style: preserve-3d;
   animation: floatCube 5.5s ease-in-out infinite;
 }
@@ -351,7 +343,7 @@ body {
   color: var(--spark-color);
   font-size: var(--spark-size);
   font-weight: 900;
-  text-shadow: 0 0 12px currentColor;
+  text-shadow: 0 0 8px currentColor;
   transform: translate3d(-50%, -50%, 0) scale(0.5) rotate(0deg);
   animation: sparkFly var(--spark-life) cubic-bezier(0.12, 0.75, 0.2, 1) forwards;
 }
@@ -390,23 +382,20 @@ body {
   border-top-color: rgba(255, 215, 0, 0.95);
   border-left-color: rgba(255, 47, 168, 0.7);
   border-right-color: rgba(34, 217, 255, 0.85);
-  filter: drop-shadow(0 0 38px rgba(255, 215, 0, 0.85));
-  animation-duration: 2.2s;
+  opacity: 0.9;
 }
 
 #app.combo-fever .warp-grid {
   opacity: 1;
-  animation-duration: 0.4s;
-  filter: drop-shadow(0 0 22px rgba(255, 215, 0, 0.7));
+  opacity: 0.72;
 }
 
 #app.combo-fever::before {
-  animation-duration: 3.5s;
-  filter: blur(18px) saturate(2);
+  filter: blur(8px);
 }
 
 #app.combo-fever .floating-kuku span {
-  filter: saturate(2) drop-shadow(0 0 24px rgba(255, 215, 0, 0.8)) brightness(1.2);
+  filter: saturate(1.35) brightness(1.08);
 }
 
 #app[data-screen="game"] .floating-kuku span {
@@ -416,7 +405,7 @@ body {
   font-size: clamp(1rem, 4vw, 1.32rem);
   opacity: 0.92;
   animation: neonSideFloat 3.4s ease-in-out infinite;
-  filter: saturate(1.45) drop-shadow(0 0 18px rgba(255, 215, 0, 0.42));
+  filter: saturate(1.18);
 }
 
 #app[data-screen="game"] .floating-kuku span:nth-child(1) { left: -28px; top: 7%; }
@@ -461,15 +450,15 @@ body {
 
 @keyframes sparkFly {
   0% { opacity: 1; transform: translate3d(-50%, -50%, 0) scale(0.3) rotate(0deg); }
-  30% { opacity: 1; transform: translate3d(calc(var(--x) * 0.45 - 50%), calc(var(--y) * 0.4 - 50%), 0) scale(1.6) rotate(calc(var(--spin) * 0.4)); }
-  72% { opacity: 1; transform: translate3d(calc(var(--x) * 0.85 - 50%), calc(var(--y) * 0.85 - 50%), 0) scale(1.4) rotate(calc(var(--spin) * 0.8)); }
+  30% { opacity: 1; transform: translate3d(calc(var(--x) * 0.45 - 50%), calc(var(--y) * 0.4 - 50%), 0) scale(1.35) rotate(calc(var(--spin) * 0.4)); }
+  72% { opacity: 1; transform: translate3d(calc(var(--x) * 0.85 - 50%), calc(var(--y) * 0.85 - 50%), 0) scale(1.15) rotate(calc(var(--spin) * 0.8)); }
   100% { opacity: 0; transform: translate3d(calc(var(--x) - 50%), calc(var(--y) + 60px - 50%), 0) scale(0.6) rotate(var(--spin)); }
 }
 
 @keyframes correctPunch {
   0% { transform: rotateX(0deg) rotateY(0deg) scale(1); box-shadow: 0 16px 34px rgba(59,36,124,0.12), inset 0 0 0 2px rgba(255,255,255,0.85); }
-  30% { transform: rotateX(15deg) rotateY(-8deg) scale(1.12); box-shadow: 0 22px 60px rgba(255, 215, 0, 0.55), 0 0 80px rgba(255, 105, 180, 0.4), inset 0 0 0 3px rgba(255, 215, 0, 0.95); }
-  55% { transform: rotateX(-10deg) rotateY(10deg) scale(0.98); box-shadow: 0 22px 60px rgba(78, 205, 196, 0.5), 0 0 60px rgba(101, 214, 255, 0.5), inset 0 0 0 3px rgba(78, 205, 196, 0.85); }
+  30% { transform: rotateX(12deg) rotateY(-6deg) scale(1.08); box-shadow: 0 18px 36px rgba(255, 215, 0, 0.38), inset 0 0 0 3px rgba(255, 215, 0, 0.85); }
+  55% { transform: rotateX(-8deg) rotateY(8deg) scale(0.99); box-shadow: 0 18px 36px rgba(78, 205, 196, 0.35), inset 0 0 0 3px rgba(78, 205, 196, 0.75); }
   78% { transform: rotateX(6deg) rotateY(-4deg) scale(1.04); }
   100% { transform: rotateX(0deg) rotateY(0deg) scale(1); }
 }
@@ -481,4 +470,3 @@ body {
   55% { transform: translateX(-10px) rotateZ(-1.8deg); box-shadow: 0 16px 34px rgba(255, 47, 168, 0.4), inset 0 0 0 3px rgba(255, 47, 168, 0.6); }
   75% { transform: translateX(7px) rotateZ(1deg); }
 }
-

--- a/css/feedback.css
+++ b/css/feedback.css
@@ -18,37 +18,35 @@
   font-size: 12rem;
   font-weight: 900;
   text-shadow:
-    0 0 30px rgba(255,255,255,1),
-    0 0 60px currentColor,
-    0 0 90px currentColor,
-    0 18px 44px rgba(59,36,124,0.4);
+    0 0 18px rgba(255,255,255,0.95),
+    0 0 34px currentColor,
+    0 12px 28px rgba(59,36,124,0.28);
   transform: scale(0) rotate(-180deg);
   transition: none;
-  filter: drop-shadow(0 0 22px currentColor);
 }
 
 .feedback-icon.pop-correct {
-  animation: feedbackPopCorrect 1.4s cubic-bezier(0.2, 1.6, 0.3, 1) forwards;
+  animation: feedbackPopCorrect 1.15s cubic-bezier(0.2, 1.4, 0.3, 1) forwards;
 }
 
 .feedback-icon.pop-incorrect {
-  animation: feedbackPopIncorrect 1.4s cubic-bezier(0.2, 1.4, 0.3, 1) forwards;
+  animation: feedbackPopIncorrect 1.15s cubic-bezier(0.2, 1.3, 0.3, 1) forwards;
 }
 
 @keyframes feedbackPopCorrect {
   0% { transform: scale(0) rotate(-360deg); opacity: 0; }
-  35% { transform: scale(1.4) rotate(20deg); opacity: 1; }
+  35% { transform: scale(1.25) rotate(16deg); opacity: 1; }
   55% { transform: scale(1.1) rotate(-12deg); opacity: 1; }
   70% { transform: scale(1.25) rotate(8deg); opacity: 1; }
   85% { transform: scale(1.15) rotate(0deg); opacity: 0.9; }
-  100% { transform: scale(2.5) rotate(0deg); opacity: 0; }
+  100% { transform: scale(1.9) rotate(0deg); opacity: 0; }
 }
 
 @keyframes feedbackPopIncorrect {
   0% { transform: scale(0) rotate(0deg); opacity: 0; }
-  20% { transform: scale(1.5) rotate(-15deg); opacity: 1; }
-  35% { transform: scale(1.3) rotate(15deg); opacity: 1; }
-  50% { transform: scale(1.4) rotate(-10deg); opacity: 1; }
+  20% { transform: scale(1.3) rotate(-12deg); opacity: 1; }
+  35% { transform: scale(1.15) rotate(12deg); opacity: 1; }
+  50% { transform: scale(1.24) rotate(-8deg); opacity: 1; }
   65% { transform: scale(1.2) rotate(8deg); opacity: 1; }
   80% { transform: scale(1.3) rotate(0deg); opacity: 0.85; }
   100% { transform: scale(0.5) rotate(0deg); opacity: 0; }
@@ -74,7 +72,7 @@
 
 @keyframes ringExpand {
   0% { transform: translate(-50%, -50%) scale(0); opacity: 1; border-width: 16px; }
-  100% { transform: translate(-50%, -50%) scale(8); opacity: 0; border-width: 1px; }
+  100% { transform: translate(-50%, -50%) scale(5.5); opacity: 0; border-width: 1px; }
 }
 
 .correct {
@@ -97,12 +95,10 @@
   text-align: center;
   margin-bottom: 15px;
   box-shadow:
-    0 10px 30px rgba(255, 215, 0, 0.45),
-    0 0 60px rgba(255, 105, 180, 0.35),
+    0 8px 22px rgba(255, 215, 0, 0.3),
+    0 0 26px rgba(255, 105, 180, 0.22),
     inset 0 0 0 2px rgba(255,255,255,0.95);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
-  animation: scoreBoardFloat 3s ease-in-out infinite, scoreBoardEnter 0.9s cubic-bezier(0.2, 1.5, 0.3, 1);
+  animation: scoreBoardEnter 0.75s cubic-bezier(0.2, 1.4, 0.3, 1);
   position: relative;
   overflow: visible;
 }
@@ -112,11 +108,9 @@
   position: absolute;
   inset: -8px;
   border-radius: 28px;
-  background: conic-gradient(from 0deg, #ff2fa8, #ffd700, #4ecdc4, #65d6ff, #a8f04f, #ff2fa8);
-  filter: blur(12px);
-  opacity: 0.55;
+  background: linear-gradient(90deg, #ff2fa8, #ffd700, #4ecdc4, #65d6ff, #a8f04f);
+  opacity: 0.28;
   z-index: -1;
-  animation: scoreBoardSpin 4s linear infinite;
 }
 
 @keyframes scoreBoardEnter {
@@ -144,13 +138,12 @@
   font-weight: 900;
   color: var(--main-pink);
   line-height: 1.2;
-  text-shadow: 3px 3px 0 #fff, 0 0 30px rgba(255, 105, 180, 0.7), 0 0 60px var(--gold);
-  animation: scorePulse 1.2s ease-in-out infinite;
+  text-shadow: 3px 3px 0 #fff, 0 0 18px rgba(255, 105, 180, 0.45);
 }
 
 @keyframes scorePulse {
-  0%, 100% { transform: scale(1); filter: hue-rotate(0deg); }
-  50% { transform: scale(1.08); filter: hue-rotate(15deg); }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
 }
 
 .perfect-msg {
@@ -158,8 +151,7 @@
   font-weight: 900;
   font-size: 1.1rem;
   margin-top: 10px;
-  text-shadow: 0 2px 0 #fff, 0 0 18px var(--gold);
-  animation: perfectMsgWave 1.6s ease-in-out infinite;
+  text-shadow: 0 2px 0 #fff, 0 0 10px rgba(255, 215, 0, 0.5);
 }
 
 @keyframes perfectMsgWave {
@@ -184,4 +176,3 @@
   align-items: center;
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
-

--- a/css/game.css
+++ b/css/game.css
@@ -63,10 +63,10 @@
   color: #fff;
   font-size: clamp(1.6rem, 8vw, 2.7rem);
   font-weight: 900;
-  text-shadow: 0 3px 0 rgba(59, 36, 124, 0.22), 0 0 18px rgba(255,255,255,0.9), 0 0 30px var(--gold);
-  box-shadow: 0 18px 42px rgba(59, 36, 124, 0.22), 0 0 35px rgba(255, 105, 180, 0.45), inset 0 0 0 3px rgba(255,255,255,0.62);
+  text-shadow: 0 3px 0 rgba(59, 36, 124, 0.22), 0 0 12px rgba(255,255,255,0.8);
+  box-shadow: 0 14px 28px rgba(59, 36, 124, 0.18), 0 0 18px rgba(255, 105, 180, 0.26), inset 0 0 0 3px rgba(255,255,255,0.62);
   transform-style: preserve-3d;
-  animation: coreFloat 2.4s ease-in-out infinite, coreGlow 2.8s ease-in-out infinite;
+  animation: coreFloat 3s ease-in-out infinite;
 }
 
 @keyframes coreGlow {
@@ -99,8 +99,8 @@
   border-right-color: rgba(78, 205, 196, 0.65);
   border-radius: 50%;
   transform: rotateX(70deg) rotateZ(0deg);
-  animation: stageRing 2.2s linear infinite;
-  filter: drop-shadow(0 0 14px rgba(255,255,255,0.7));
+  animation: stageRing 4.2s linear infinite;
+  opacity: 0.72;
 }
 
 .stage-ring.back {
@@ -118,7 +118,7 @@
   height: 22px;
   border-radius: 50%;
   background: var(--gold);
-  box-shadow: 0 0 0 10px rgba(255,215,0,0.32), 0 0 40px rgba(255,215,0,1), 0 0 80px rgba(255, 105, 180, 0.6);
+  box-shadow: 0 0 0 7px rgba(255,215,0,0.22), 0 0 24px rgba(255,215,0,0.72);
   transform-origin: 108px 50%;
   animation: cometRun 1.1s linear infinite;
 }
@@ -132,7 +132,6 @@
   height: 4px;
   background: linear-gradient(to left, rgba(255, 215, 0, 0.85), transparent);
   transform: translateY(-50%);
-  filter: blur(2px);
 }
 
 .stage-mini {
@@ -154,7 +153,7 @@
 
 #app.combo-fever .stage-core {
   animation-duration: 1.2s;
-  box-shadow: 0 18px 52px rgba(255, 105, 180, 0.36), 0 0 36px rgba(255, 215, 0, 0.42), inset 0 0 0 3px rgba(255,255,255,0.68);
+  box-shadow: 0 14px 32px rgba(255, 105, 180, 0.28), 0 0 22px rgba(255, 215, 0, 0.28), inset 0 0 0 3px rgba(255,255,255,0.68);
 }
 
 @keyframes coreFloat {
@@ -191,10 +190,8 @@
     linear-gradient(180deg, rgba(255,255,255,0.9), rgba(255,255,255,0.78)),
     radial-gradient(circle at 18% 22%, rgba(255, 105, 180, 0.18), transparent 38%),
     radial-gradient(circle at 82% 82%, rgba(78, 205, 196, 0.16), transparent 40%);
-  box-shadow: 0 16px 34px rgba(59,36,124,0.12), inset 0 0 0 2px rgba(255,255,255,0.85);
+  box-shadow: 0 10px 22px rgba(59,36,124,0.1), inset 0 0 0 2px rgba(255,255,255,0.85);
   transform-style: preserve-3d;
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
 }
 
 .question-area::before {
@@ -209,8 +206,7 @@
     linear-gradient(180deg, rgba(255,105,180,0.64), rgba(101,214,255,0.55)) left / 5px 100% no-repeat,
     linear-gradient(180deg, rgba(255,215,0,0.68), rgba(168,240,79,0.58)) right / 5px 100% no-repeat;
   opacity: 0.74;
-  filter: drop-shadow(0 0 12px rgba(255, 105, 180, 0.3));
-  animation: questionGlow 2.8s ease-in-out infinite;
+  opacity: 0.62;
 }
 
 .question-area::after {
@@ -223,9 +219,7 @@
   border-radius: 999px;
   background:
     repeating-linear-gradient(90deg, #ff2fa8 0 10px, #ffd700 10px 20px, #4ecdc4 20px 30px, #65d6ff 30px 40px);
-  box-shadow: 0 0 16px rgba(255, 215, 0, 0.34);
-  opacity: 0.72;
-  animation: questionMeter 0.7s steps(6) infinite;
+  opacity: 0.58;
 }
 
 @keyframes questionGlow {
@@ -241,7 +235,7 @@
   font-size: 2.2rem;
   font-weight: 900;
   color: var(--main-pink);
-  text-shadow: 2px 2px 0 #fff, 0 10px 22px rgba(255, 105, 180, 0.22);
+  text-shadow: 2px 2px 0 #fff, 0 6px 14px rgba(255, 105, 180, 0.18);
   margin-bottom: 6px;
   letter-spacing: 1px;
   min-height: 2.5rem;
@@ -321,7 +315,7 @@
 .equation-slot.active-slot {
   border-color: var(--main-pink);
   background: rgba(255, 105, 180, 0.1);
-  animation: slotPulse 1s infinite;
+  animation: slotPulse 1.8s ease-in-out infinite;
 }
 
 .equation-slot.filled-slot {
@@ -366,7 +360,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--btn-shadow), 0 0 0 0 rgba(78, 205, 196, 0);
+  box-shadow: var(--btn-shadow);
   cursor: pointer;
   transition: transform 0.12s, box-shadow 0.12s, filter 0.12s;
   overflow: hidden;
@@ -385,12 +379,12 @@
 .num-btn:hover {
   filter: saturate(1.3) brightness(1.05);
   transform: translateY(-3px) scale(1.05);
-  box-shadow: 0 8px 16px rgba(78, 205, 196, 0.35), 0 0 18px rgba(78, 205, 196, 0.4);
+  box-shadow: 0 7px 12px rgba(78, 205, 196, 0.24);
 }
 
 .num-btn:active {
   transform: translateY(4px) scale(0.92);
-  box-shadow: var(--btn-active-shadow), 0 0 24px rgba(78, 205, 196, 0.7);
+  box-shadow: var(--btn-active-shadow), 0 0 12px rgba(78, 205, 196, 0.36);
   background-color: var(--mint);
   color: var(--white);
 }
@@ -405,7 +399,7 @@
 }
 
 .num-btn.btn-enter:active {
-  box-shadow: var(--btn-active-shadow), 0 0 28px rgba(255, 105, 180, 0.85);
+  box-shadow: var(--btn-active-shadow), 0 0 14px rgba(255, 105, 180, 0.45);
 }
 
 .action-btn {
@@ -425,4 +419,3 @@
   border-color: white;
   grid-column: span 1;
 }
-

--- a/js/audio.js
+++ b/js/audio.js
@@ -1,10 +1,21 @@
 
+let currentBgmKey = null;
+let isBgmStarting = false;
+let isBgmPlaying = false;
+let audioInitPromise = null;
+
 function initAudio() {
   if (!audioCtx) {
     audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   }
   if (audioCtx.state === 'suspended') {
-    audioCtx.resume();
+    audioInitPromise = audioInitPromise || audioCtx.resume()
+      .catch((error) => {
+        console.warn('Audio resume failed', error);
+      })
+      .finally(() => {
+        audioInitPromise = null;
+      });
   }
   if (!audioInitialized) {
     isMuted = false;
@@ -37,24 +48,34 @@ function updateMuteIcon() {
 
 
 function selectSong(index) {
+  const previousSongIndex = currentSongIndex;
   currentSongIndex = index;
   localStorage.setItem('kuku_bgm', index);
   noteIndex = 0;
   document.querySelectorAll('.bgm-option').forEach((el, i) => {
     el.classList.toggle('bgm-active', i === index);
   });
-  if (!isMuted && bgmTimer) {
+  if (!isMuted && previousSongIndex !== index) {
     stopBgm();
-    startBgm();
   }
   initAudio();
   playSe('btn');
 }
 
 function startBgm() {
-  if (isMuted || bgmTimer) return;
+  if (isMuted) return;
   const song = BGM_SONGS[currentSongIndex];
+  if (!song) return;
+  const requestedKey = getBgmKey(song, currentSongIndex);
+  if ((isBgmPlaying || isBgmStarting) && currentBgmKey === requestedKey) return;
+  if (bgmTimer || activeToneEngine || isBgmPlaying || isBgmStarting) {
+    stopBgm();
+  }
+
   if (song.useTone) {
+    currentBgmKey = requestedKey;
+    isBgmStarting = true;
+    isBgmPlaying = false;
     bgmTimer = 'tone';
     const token = ++bgmStartToken;
     startToneEngine(() => token === bgmStartToken && bgmTimer === 'tone' && !isMuted)
@@ -62,12 +83,26 @@ function startBgm() {
         if (token !== bgmStartToken) {
           return;
         }
+        isBgmStarting = false;
+        isBgmPlaying = !!started;
         if (!started && bgmTimer === 'tone') {
           bgmTimer = null;
+          currentBgmKey = null;
         }
+      })
+      .catch((error) => {
+        if (token !== bgmStartToken) return;
+        console.warn('BGM start failed', error);
+        isBgmStarting = false;
+        isBgmPlaying = false;
+        bgmTimer = null;
+        currentBgmKey = null;
       });
     return;
   }
+  currentBgmKey = requestedKey;
+  isBgmStarting = false;
+  isBgmPlaying = true;
   bgmStartToken++;
   scheduleNextNote();
 }
@@ -77,13 +112,29 @@ function stopBgm() {
   stopToneEngine();
   if (bgmTimer && bgmTimer !== 'tone') clearTimeout(bgmTimer);
   bgmTimer = null;
+  currentBgmKey = null;
+  isBgmStarting = false;
+  isBgmPlaying = false;
 }
 
 function scheduleNextNote() {
-  if (isMuted) { bgmTimer = null; return; }
-  if (!audioCtx) return;
+  if (isMuted) {
+    bgmTimer = null;
+    isBgmPlaying = false;
+    return;
+  }
+  if (!audioCtx) {
+    isBgmPlaying = false;
+    return;
+  }
 
   const song = BGM_SONGS[currentSongIndex];
+  if (!song) {
+    bgmTimer = null;
+    isBgmPlaying = false;
+    currentBgmKey = null;
+    return;
+  }
   if (song.useTone) { bgmTimer = 'tone'; return; }
   const freq = song.melody[noteIndex % song.melody.length];
   const now = audioCtx.currentTime;
@@ -112,6 +163,21 @@ function scheduleNextNote() {
   bgmTimer = setTimeout(scheduleNextNote, song.tempo * 1000);
 }
 
+function getBgmKey(song, index) {
+  return song.useTone ? `tone:${song.toneBuilder}` : `web:${index}`;
+}
+
+function disconnectAudioNodes(nodes) {
+  nodes.forEach((node) => {
+    if (!node || typeof node.disconnect !== 'function') return;
+    try {
+      node.disconnect();
+    } catch (error) {
+      // 既に切断済みの場合は何もしない
+    }
+  });
+}
+
 function playBgmTone(freq, waveType, level, duration, startTime, detune = 0) {
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
@@ -124,6 +190,10 @@ function playBgmTone(freq, waveType, level, duration, startTime, detune = 0) {
   gain.connect(audioCtx.destination);
   osc.start(startTime);
   osc.stop(startTime + duration);
+  osc.onended = () => {
+    disconnectAudioNodes([osc, gain]);
+    osc.onended = null;
+  };
 }
 
 function playBgmBeat(index, now, tempo) {
@@ -137,6 +207,10 @@ function playBgmBeat(index, now, tempo) {
   hatGain.connect(audioCtx.destination);
   hat.start(now);
   hat.stop(now + Math.min(0.06, tempo * 0.6));
+  hat.onended = () => {
+    disconnectAudioNodes([hat, hatGain]);
+    hat.onended = null;
+  };
 
   if (index % 4 === 0) {
     const kick = audioCtx.createOscillator();
@@ -150,5 +224,9 @@ function playBgmBeat(index, now, tempo) {
     kickGain.connect(audioCtx.destination);
     kick.start(now);
     kick.stop(now + 0.13);
+    kick.onended = () => {
+      disconnectAudioNodes([kick, kickGain]);
+      kick.onended = null;
+    };
   }
 }

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -1,5 +1,71 @@
 
+const feedbackTimers = new Set();
+const feedbackElements = new Set();
+
+function setFeedbackTimer(callback, delay) {
+  const timerId = setTimeout(() => {
+    feedbackTimers.delete(timerId);
+    callback();
+  }, delay);
+  feedbackTimers.add(timerId);
+  return timerId;
+}
+
+function trackFeedbackElement(element) {
+  if (element) feedbackElements.add(element);
+  return element;
+}
+
+function removeFeedbackElement(element) {
+  if (!element) return;
+  feedbackElements.delete(element);
+  try {
+    element.getAnimations().forEach((animation) => animation.cancel());
+  } catch (error) {
+    // getAnimations 非対応環境では何もしない
+  }
+  element.remove();
+}
+
+function cleanupFeedbackEffects() {
+  feedbackTimers.forEach((timerId) => clearTimeout(timerId));
+  feedbackTimers.clear();
+
+  Array.from(feedbackElements).forEach((element) => removeFeedbackElement(element));
+  feedbackElements.clear();
+
+  const burstLayer = document.getElementById('burst-layer');
+  if (burstLayer) {
+    Array.from(burstLayer.children).forEach((element) => removeFeedbackElement(element));
+  }
+
+  const overlay = document.getElementById('feedback-overlay');
+  const icon = document.getElementById('feedback-icon');
+  const ring = document.getElementById('feedback-ring');
+  const ring2 = document.getElementById('feedback-ring-2');
+  const flash = document.getElementById('screen-flash');
+  const app = document.getElementById('app');
+  [overlay, icon, ring, ring2, flash, app].forEach((element) => {
+    if (!element) return;
+    try {
+      element.getAnimations().forEach((animation) => animation.cancel());
+    } catch (error) {
+      // getAnimations 非対応環境では何もしない
+    }
+  });
+  if (overlay) overlay.style.opacity = 0;
+  if (icon) {
+    icon.style.transform = '';
+    icon.classList.remove('pop-correct', 'pop-incorrect', 'correct', 'incorrect');
+  }
+  if (ring) ring.classList.remove('active', 'correct', 'incorrect');
+  if (ring2) ring2.classList.remove('active', 'correct', 'incorrect');
+  if (flash) flash.classList.remove('active', 'correct', 'incorrect', 'fever');
+  if (app) app.classList.remove('hit-correct', 'hit-incorrect', 'shake-correct', 'shake-incorrect', 'zoom-pop');
+}
+
 function showFeedback(isCorrect) {
+  cleanupFeedbackEffects();
   const overlay = document.getElementById('feedback-overlay');
   const icon = document.getElementById('feedback-icon');
   const ring = document.getElementById('feedback-ring');
@@ -22,11 +88,11 @@ function showFeedback(isCorrect) {
     app.classList.add(isCorrect ? 'hit-correct' : 'hit-incorrect');
     launchBurst(isCorrect, isFever);
     requestAnimationFrame(() => { icon.style.transform = 'scale(1)'; });
-    setTimeout(() => {
+    setFeedbackTimer(() => {
       icon.style.transform = 'scale(0)';
       overlay.style.opacity = 0;
       app.classList.remove('hit-correct', 'hit-incorrect');
-    }, 1500);
+    }, 1200);
     return;
   }
 
@@ -57,25 +123,25 @@ function showFeedback(isCorrect) {
   icon.classList.add(isCorrect ? 'pop-correct' : 'pop-incorrect');
   void ring.offsetWidth;
   ring.classList.add('active');
-  setTimeout(() => {
+  setFeedbackTimer(() => {
     void ring2.offsetWidth;
     ring2.classList.add('active');
-  }, 120);
+  }, 100);
 
   launchBurst(isCorrect, isFever);
   if (isCorrect) {
     launchLasers(isFever);
-    if (isFever) launchConfetti(20);
+    if (isFever) launchConfetti(12);
   }
 
-  setTimeout(() => {
+  setFeedbackTimer(() => {
     overlay.style.opacity = 0;
     icon.classList.remove('pop-correct', 'pop-incorrect');
     ring.classList.remove('active');
     ring2.classList.remove('active');
     flash.classList.remove('active', 'correct', 'incorrect', 'fever');
     app.classList.remove('hit-correct', 'hit-incorrect', 'shake-correct', 'shake-incorrect', 'zoom-pop');
-  }, 1500);
+  }, 1200);
 }
 
 function getParticleBudget(layer, requested) {
@@ -89,7 +155,7 @@ function launchLasers(isBig) {
   if (prefersReducedMotion() || isLegacyFx()) return;
   const layer = document.getElementById('burst-layer');
   if (!layer) return;
-  const requested = isBig ? 12 : 8;
+  const requested = isBig ? 8 : 5;
   const count = getParticleBudget(layer, requested);
   if (count === 0) return;
   const colors = ['#FFD700', '#FF69B4', '#4ECDC4', '#65D6FF', '#A8F04F'];
@@ -99,7 +165,8 @@ function launchLasers(isBig) {
     laser.style.setProperty('--angle', `${(360 / count) * i + Math.random() * 12}deg`);
     laser.style.setProperty('--laser-color', colors[i % colors.length]);
     layer.appendChild(laser);
-    setTimeout(() => laser.remove(), 800);
+    trackFeedbackElement(laser);
+    setFeedbackTimer(() => removeFeedbackElement(laser), 650);
   }
 }
 
@@ -117,10 +184,11 @@ function launchConfetti(count) {
     c.style.setProperty('--csize', `${6 + Math.random() * 8}px`);
     c.style.setProperty('--ccolor', colors[i % colors.length]);
     c.style.setProperty('--crot', `${Math.random() * 360}deg`);
-    c.style.setProperty('--cdx', `${(Math.random() - 0.5) * 280}px`);
-    c.style.setProperty('--clife', `${1800 + Math.random() * 1400}ms`);
+    c.style.setProperty('--cdx', `${(Math.random() - 0.5) * 220}px`);
+    c.style.setProperty('--clife', `${1200 + Math.random() * 700}ms`);
     layer.appendChild(c);
-    setTimeout(() => c.remove(), 3400);
+    trackFeedbackElement(c);
+    setFeedbackTimer(() => removeFeedbackElement(c), 2100);
   }
 }
 
@@ -140,7 +208,8 @@ function launchShootingStar() {
   star.style.setProperty('--ssdy', `${150 + Math.random() * 150}px`);
   star.style.setProperty('--ssc', colors[Math.floor(Math.random() * colors.length)]);
   layer.appendChild(star);
-  setTimeout(() => star.remove(), 1500);
+  trackFeedbackElement(star);
+  setFeedbackTimer(() => removeFeedbackElement(star), 1100);
 }
 
 function launchBurst(isCorrect, isBig) {
@@ -157,8 +226,8 @@ function launchBurst(isCorrect, isBig) {
   const centerX = questionRect.left - appRect.left + questionRect.width / 2;
   const centerY = questionRect.top - appRect.top + questionRect.height / 2;
   const requested = legacy
-    ? (isBig ? 42 : (isCorrect ? 28 : 18))
-    : (isBig ? 90 : (isCorrect ? 60 : 36));
+    ? (isBig ? 30 : (isCorrect ? 22 : 14))
+    : (isBig ? 58 : (isCorrect ? 38 : 24));
   const count = getParticleBudget(layer, requested);
   const symbols = isCorrect
     ? (legacy ? ['★', '×', '+', '♪'] : ['★', '✦', '♥', '♪', '✿', '◆', '✺'])
@@ -189,18 +258,19 @@ function launchBurst(isCorrect, isBig) {
       ? `${14 + Math.random() * (isBig ? 18 : 12)}px`
       : `${18 + Math.random() * (isBig ? 28 : 18)}px`);
     spark.style.setProperty('--spark-life', legacy
-      ? `${780 + Math.random() * 420}ms`
-      : `${900 + Math.random() * 600}ms`);
+      ? `${650 + Math.random() * 300}ms`
+      : `${720 + Math.random() * 420}ms`);
     layer.appendChild(spark);
-    setTimeout(() => spark.remove(), legacy ? 1300 : 1600);
+    trackFeedbackElement(spark);
+    setFeedbackTimer(() => removeFeedbackElement(spark), legacy ? 1050 : 1300);
   }
 
   if (legacy) return;
 
   // 二次バースト（少し遅れて 別方向に）
   if (isCorrect) {
-    setTimeout(() => {
-      const secondRequested = isBig ? 50 : 30;
+    setFeedbackTimer(() => {
+      const secondRequested = isBig ? 26 : 18;
       const secondCount = getParticleBudget(layer, secondRequested);
       if (secondCount === 0) return;
       for (let i = 0; i < secondCount; i++) {
@@ -218,15 +288,19 @@ function launchBurst(isCorrect, isBig) {
         spark.style.setProperty('--spin', `${(Math.random() * 720 - 360).toFixed(0)}deg`);
         spark.style.setProperty('--spark-color', colors[i % colors.length]);
         spark.style.setProperty('--spark-size', `${16 + Math.random() * 14}px`);
-        spark.style.setProperty('--spark-life', `${800 + Math.random() * 500}ms`);
+        spark.style.setProperty('--spark-life', `${650 + Math.random() * 340}ms`);
         layer.appendChild(spark);
-        setTimeout(() => spark.remove(), 1400);
+        trackFeedbackElement(spark);
+        setFeedbackTimer(() => removeFeedbackElement(spark), 1100);
       }
-    }, 180);
+    }, 150);
   }
 }
 
 function endGame() {
+  invalidateGameSession();
+  cleanupFeedbackEffects();
+  cleanupStageAnimation();
   showScreen('result-screen');
   playSe('result');
   const isPerfect = score === totalQuestions;
@@ -237,7 +311,7 @@ function endGame() {
 
   if (legacy) {
     finalScoreEl.textContent = `${score} / ${totalQuestions}`;
-    setTimeout(() => {
+    setFeedbackTimer(() => {
       if (score > 0) launchBurst(true, isPerfect);
     }, 180);
   } else {
@@ -251,33 +325,33 @@ function endGame() {
       displayed++;
       finalScoreEl.textContent = `${displayed} / ${totalQuestions}`;
       playSe('btn');
-      if (displayed < score) setTimeout(tickScore, stepDuration);
+      if (displayed < score) setFeedbackTimer(tickScore, stepDuration);
     };
-    setTimeout(tickScore, 400);
+    setFeedbackTimer(tickScore, 400);
 
     // 初回 大バースト
-    setTimeout(() => {
+    setFeedbackTimer(() => {
       if (score > 0) launchBurst(true, isPerfect);
     }, 180);
 
     // 紙吹雪 連発
     if (score > 0) {
-      const burstCount = isPerfect ? 4 : Math.min(5, Math.ceil(score / 2));
+      const burstCount = isPerfect ? 3 : Math.min(3, Math.ceil(score / 3));
       for (let i = 0; i < burstCount; i++) {
-        setTimeout(() => launchConfetti(isPerfect ? 30 : 18), 300 + i * 280);
+        setFeedbackTimer(() => launchConfetti(isPerfect ? 18 : 12), 260 + i * 240);
       }
     }
 
     // パーフェクト時 花火連発＋流れ星
     if (isPerfect) {
-      for (let i = 0; i < 3; i++) {
-        setTimeout(() => {
+      for (let i = 0; i < 2; i++) {
+        setFeedbackTimer(() => {
           launchBurst(true, true);
           launchLasers(true);
-        }, 700 + i * 450);
+        }, 600 + i * 360);
       }
-      for (let i = 0; i < 4; i++) {
-        setTimeout(launchShootingStar, 600 + i * 250);
+      for (let i = 0; i < 2; i++) {
+        setFeedbackTimer(launchShootingStar, 540 + i * 240);
       }
     }
   }
@@ -294,4 +368,3 @@ function endGame() {
     speak("またチャレンジしてね！");
   }
 }
-

--- a/js/free-select.js
+++ b/js/free-select.js
@@ -51,6 +51,7 @@ function clearAllFree() {
 
 function startFreeGame() {
   if (selectedFreeProblems.size === 0) return;
+  const sessionId = invalidateGameSession();
   isFreeMode = true;
 
   const candidates = [...selectedFreeProblems].map(key => {
@@ -80,6 +81,5 @@ function startFreeGame() {
   initVoice(); initAudio(); speak("");
   updateStatusBar();
   showScreen('game-screen');
-  setTimeout(showNextQuestion, 500);
+  scheduleGameProgressTimer(() => showNextQuestion(sessionId), 500, sessionId);
 }
-

--- a/js/game.js
+++ b/js/game.js
@@ -1,4 +1,6 @@
 
+let stageUpdateAnimation = null;
+
 // 画面切り替え
 function showScreen(screenId) {
   document.querySelectorAll('.screen').forEach(el => {
@@ -10,6 +12,9 @@ function showScreen(screenId) {
 
 // ゲーム開始
 function startGame(mode) {
+  const sessionId = invalidateGameSession();
+  cleanupFeedbackEffects();
+  cleanupStageAnimation();
   // 音声初期化（ユーザー操作トリガー）
   initVoice();
   initAudio();
@@ -57,7 +62,7 @@ function startGame(mode) {
   showScreen('game-screen');
   
   // 少し待ってから最初の問題を表示
-  setTimeout(showNextQuestion, 500);
+  scheduleGameProgressTimer(() => showNextQuestion(sessionId), 500, sessionId);
 }
 
 function shuffleArray(array) {
@@ -68,7 +73,9 @@ function shuffleArray(array) {
   return array;
 }
 
-function showNextQuestion() {
+function showNextQuestion(sessionId = getCurrentGameSessionId()) {
+  if (!isCurrentGameSession(sessionId)) return;
+
   if (currentQuestionIndex >= totalQuestions) {
     endGame();
     return;
@@ -166,8 +173,9 @@ function updateStage(q) {
   stageNumber.textContent = currentQuestionType === "equation" ? `${q.a}×?` : `${q.a}×${q.b}`;
   stageLeft.textContent = q.a;
   stageRight.textContent = currentQuestionType === "equation" ? "?" : q.b;
+  cleanupStageAnimation();
   if (!prefersReducedMotion()) {
-    stageNumber.animate(
+    stageUpdateAnimation = stageNumber.animate(
       [
         { transform: 'rotateX(10deg) rotateY(-16deg) translateY(0) translateZ(20px) scale(0.88)' },
         { transform: 'rotateX(-8deg) rotateY(18deg) translateY(-10px) translateZ(44px) scale(1.08)' },
@@ -175,7 +183,23 @@ function updateStage(q) {
       ],
       { duration: 520, easing: 'cubic-bezier(0.2, 1.4, 0.3, 1)' }
     );
+    stageUpdateAnimation.onfinish = () => {
+      stageUpdateAnimation = null;
+    };
+    stageUpdateAnimation.oncancel = () => {
+      stageUpdateAnimation = null;
+    };
   }
+}
+
+function cleanupStageAnimation() {
+  if (!stageUpdateAnimation) return;
+  try {
+    stageUpdateAnimation.cancel();
+  } catch (error) {
+    // 既に終了済みなら何もしない
+  }
+  stageUpdateAnimation = null;
 }
 
 function inputNum(num) {
@@ -233,6 +257,7 @@ function updateEquationDisplay() {
 function submitAnswer() {
   if (isProcessing) return;
 
+  const sessionId = getCurrentGameSessionId();
   const q = currentQuestions[currentQuestionIndex];
   const kukuReadingEl = document.getElementById('kuku-reading');
 
@@ -264,15 +289,15 @@ function submitAnswer() {
       '<span>' + q.a_read + '</span>';
 
     // 正解の読み上げ
-    setTimeout(() => {
+    scheduleGameProgressTimer(() => {
       speak(getFullSpeak(q));
-    }, 500);
+    }, 500, sessionId);
 
     // 次の問題へ
-    setTimeout(() => {
+    scheduleGameProgressTimer(() => {
       currentQuestionIndex++;
-      showNextQuestion();
-    }, 2500);
+      showNextQuestion(sessionId);
+    }, 2500, sessionId);
 
   } else {
     // 通常問題
@@ -301,14 +326,14 @@ function submitAnswer() {
       '<span class="kuku-revealed">' + q.a_read + '</span>';
 
     // 正解の読み上げ
-    setTimeout(() => {
+    scheduleGameProgressTimer(() => {
       speak(getFullSpeak(q));
-    }, 500);
+    }, 500, sessionId);
 
     // 次の問題へ
-    setTimeout(() => {
+    scheduleGameProgressTimer(() => {
       currentQuestionIndex++;
-      showNextQuestion();
-    }, 2500);
+      showNextQuestion(sessionId);
+    }, 2500, sessionId);
   }
 }

--- a/js/se.js
+++ b/js/se.js
@@ -2,10 +2,32 @@
 function playSe(type) {
   if (isMuted || !audioCtx) return;
   const now = audioCtx.currentTime;
+  const connectSeNodes = (source, gainNode) => {
+    source.connect(gainNode);
+    gainNode.connect(audioCtx.destination);
+    source.onended = () => {
+      disconnectSeNodes([source, gainNode]);
+      source.onended = null;
+    };
+  };
+  if (type === 'result') {
+    [523.25, 659.25, 783.99, 1046.50].forEach((f, i) => {
+      const o = audioCtx.createOscillator();
+      const g = audioCtx.createGain();
+      connectSeNodes(o, g);
+      o.type = 'triangle';
+      o.frequency.value = f;
+      g.gain.setValueAtTime(0.05, now + i * 0.1);
+      g.gain.exponentialRampToValueAtTime(0.001, now + i * 0.1 + 0.4);
+      o.start(now + i * 0.1);
+      o.stop(now + i * 0.1 + 0.4);
+    });
+    return;
+  }
+
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
-  osc.connect(gain);
-  gain.connect(audioCtx.destination);
+  connectSeNodes(osc, gain);
 
   if (type === 'btn') {
     osc.type = 'triangle';
@@ -37,18 +59,18 @@ function playSe(type) {
     gain.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
     osc.start(now);
     osc.stop(now + 0.1);
-  } else if (type === 'result') {
-    [523.25, 659.25, 783.99, 1046.50].forEach((f, i) => {
-      const o = audioCtx.createOscillator();
-      const g = audioCtx.createGain();
-      o.connect(g);
-      g.connect(audioCtx.destination);
-      o.type = 'triangle';
-      o.frequency.value = f;
-      g.gain.setValueAtTime(0.05, now + i * 0.1);
-      g.gain.exponentialRampToValueAtTime(0.001, now + i * 0.1 + 0.4);
-      o.start(now + i * 0.1);
-      o.stop(now + i * 0.1 + 0.4);
-    });
+  } else {
+    disconnectSeNodes([osc, gain]);
   }
+}
+
+function disconnectSeNodes(nodes) {
+  nodes.forEach((node) => {
+    if (!node || typeof node.disconnect !== 'function') return;
+    try {
+      node.disconnect();
+    } catch (error) {
+      // 既に切断済みなら無視する
+    }
+  });
 }

--- a/js/state.js
+++ b/js/state.js
@@ -1,7 +1,7 @@
 // 九九データ (読み仮名付き)
 // q_read / a_read: 画面表示用（ひらがな）
 // q_speak / a_speak: 読み上げ用（省略時は q_read / a_read を使用）
-//   語末の「は」は iPhone 等で助詞「わ」と解釈されるため、カタカナ「ハ」で指定して回避する
+//   語末の「は」は一部環境で助詞「わ」と解釈されるため、カタカナ「ハ」で指定して回避する
 const kukuData = [
   // 1の段
   { a: 1, b: 1, q_read: "いんいちが", a_read: "いち" },
@@ -105,6 +105,38 @@ let isProcessing = false;
 let currentQuestionType = "answer"; // "answer"（通常）or "equation"（逆問題: Q5, Q10）
 let equationInputB = "";
 let totalQuestions = parseInt(localStorage.getItem('kuku_question_count') || '10');
+let gameSessionId = 0;
+const gameProgressTimers = new Set();
+
+function clearGameProgressTimers() {
+  gameProgressTimers.forEach((timerId) => clearTimeout(timerId));
+  gameProgressTimers.clear();
+}
+
+function invalidateGameSession() {
+  clearGameProgressTimers();
+  gameSessionId++;
+  return gameSessionId;
+}
+
+function getCurrentGameSessionId() {
+  return gameSessionId;
+}
+
+function isCurrentGameSession(sessionId) {
+  return sessionId === gameSessionId;
+}
+
+function scheduleGameProgressTimer(callback, delay, sessionId) {
+  const targetSessionId = sessionId == null ? getCurrentGameSessionId() : sessionId;
+  const timerId = setTimeout(() => {
+    gameProgressTimers.delete(timerId);
+    if (!isCurrentGameSession(targetSessionId)) return;
+    callback();
+  }, delay);
+  gameProgressTimers.add(timerId);
+  return timerId;
+}
 
 // くみあわせモード
 let isCombinationMode = false;
@@ -117,8 +149,8 @@ let selectedFreeProblems = new Set(); // "a,b" 形式
 // 音声合成
 const synth = window.speechSynthesis;
 let voice = null;
-// パーティクル同時生存数の上限。iPhone Safari のメモリ不足対策。
-const PARTICLE_CAP = 200;
+// パーティクル同時生存数の上限。全端末共通で演出負荷を抑える。
+const PARTICLE_CAP = 100;
 // 九九の表モード
 let isPlayingTable = false;
 let tablePlaybackData = [];

--- a/js/title.js
+++ b/js/title.js
@@ -1,4 +1,7 @@
 function showTitle() {
+  invalidateGameSession();
+  cleanupFeedbackEffects();
+  cleanupStageAnimation();
   showScreen('title-screen');
   synth.cancel();
   playSe('cancel');
@@ -68,4 +71,3 @@ function changeQuestionCount(delta) {
   document.getElementById('question-count-display').textContent = totalQuestions;
   playSe('btn');
 }
-

--- a/js/tone-engines.js
+++ b/js/tone-engines.js
@@ -2,6 +2,7 @@
 function disposeToneNodes(disposables) {
   disposables.forEach((node) => {
     if (!node || typeof node.dispose !== 'function') return;
+    if (node.disposed) return;
     try {
       node.dispose();
     } catch (error) {
@@ -23,13 +24,46 @@ function stopToneLoops(loops) {
 
 function resetToneTransport() {
   if (typeof Tone === 'undefined') return;
+  if (!Tone.Transport) return;
   try {
-    Tone.Transport.stop();
-    Tone.Transport.cancel(0);
+    if (typeof Tone.Transport.stop === 'function') Tone.Transport.stop();
+    if (typeof Tone.Transport.cancel === 'function') Tone.Transport.cancel(0);
     Tone.Transport.position = 0;
   } catch (error) {
     console.warn('Tone transport reset failed', error);
   }
+}
+
+function createManagedToneEngine({ bpm, loops, disposables, start }) {
+  let started = false;
+  let stopped = true;
+  let disposed = false;
+
+  return {
+    bpm,
+    loops,
+    disposables,
+    start() {
+      if (disposed || started) return;
+      started = true;
+      stopped = false;
+      start.call(this);
+    },
+    stop() {
+      if (disposed || stopped) return;
+      stopToneLoops(this.loops);
+      stopped = true;
+      started = false;
+    },
+    dispose() {
+      if (disposed) return;
+      this.stop();
+      disposeToneNodes(this.disposables);
+      this.loops = [];
+      this.disposables = [];
+      disposed = true;
+    }
+  };
 }
 
 function buildToneEngineNoriNori() {
@@ -117,7 +151,7 @@ function buildToneEngineNoriNori() {
   const loops = [masterLoop];
   const disposables = [masterLoop, hat, hatFilter, clap, clapFilter, lead, bass, kick, delay, masterComp, limiter];
 
-  return {
+  return createManagedToneEngine({
     bpm: 126,
     loops,
     disposables,
@@ -125,15 +159,8 @@ function buildToneEngineNoriNori() {
       step = 0;
       Tone.Transport.bpm.value = this.bpm;
       masterLoop.start(0);
-    },
-    stop() {
-      stopToneLoops(this.loops);
-    },
-    dispose() {
-      this.stop();
-      disposeToneNodes(this.disposables);
     }
-  };
+  });
 }
 
 function buildToneEngineWakuwaku() {
@@ -233,7 +260,7 @@ function buildToneEngineWakuwaku() {
   const loops = [masterLoop];
   const disposables = [masterLoop, snare, snareFilter, rhythm, rhythmFilter, kick, bass, bell, chip, delay, masterComp, limiter];
 
-  return {
+  return createManagedToneEngine({
     bpm: 132,
     loops,
     disposables,
@@ -241,15 +268,8 @@ function buildToneEngineWakuwaku() {
       step = 0;
       Tone.Transport.bpm.value = this.bpm;
       masterLoop.start(0);
-    },
-    stop() {
-      stopToneLoops(this.loops);
-    },
-    dispose() {
-      this.stop();
-      disposeToneNodes(this.disposables);
     }
-  };
+  });
 }
 
 const TONE_BUILDERS = {
@@ -259,19 +279,20 @@ const TONE_BUILDERS = {
 
 function disposeActiveToneEngine() {
   if (!activeToneEngine) return;
+  const engine = activeToneEngine;
+  activeToneEngine = null;
+  activeToneId = null;
+  toneRunning = false;
   try {
-    activeToneEngine.stop();
+    engine.stop();
   } catch (error) {
     console.warn('Tone engine stop failed', error);
   }
   try {
-    activeToneEngine.dispose();
+    engine.dispose();
   } catch (error) {
     console.warn('Tone engine dispose failed', error);
   }
-  activeToneEngine = null;
-  activeToneId = null;
-  toneRunning = false;
 }
 
 async function startToneEngine(shouldContinue) {


### PR DESCRIPTION
This pull request primarily refines the visual appearance and animation effects across the app's CSS, focusing on making the UI less intense and more subtle, as well as simplifying some background and animation effects. There are also minor documentation updates. The most significant changes are grouped below:

**Visual Effect and Animation Adjustments:**

* Reduced the intensity of various shadows, blurs, and glows throughout `base.css`, `feedback.css`, and `game.css`, making the UI less visually overwhelming and more subtle. This includes lowering opacity, reducing blur and shadow sizes, and simplifying gradients and backgrounds. [[1]](diffhunk://#diff-3bdd5f9e87944616052f22e8443aa7bdb798fbe5f96734254e8b08f2c0a2fa0bL73-R74) [[2]](diffhunk://#diff-71bb576952a8936821b8b4e68ec1e4654587c97877cfff90496ab64ff3c6de88L21-R49) [[3]](diffhunk://#diff-3bd2e6cc3614902b56e86950c5fa61fad3f2039c00f101258e9c9883abfadc58L66-R69)
* Shortened or slowed down several animation durations and simplified animation keyframes to create smoother and less distracting transitions (e.g., `feverFlash`, `laserShoot`, floating, and feedback pop animations). [[1]](diffhunk://#diff-3bdd5f9e87944616052f22e8443aa7bdb798fbe5f96734254e8b08f2c0a2fa0bL131-R129) [[2]](diffhunk://#diff-71bb576952a8936821b8b4e68ec1e4654587c97877cfff90496ab64ff3c6de88L77-R75) [[3]](diffhunk://#diff-3bd2e6cc3614902b56e86950c5fa61fad3f2039c00f101258e9c9883abfadc58L102-R103)
* Removed or reduced the use of `filter`, `mix-blend-mode`, and other advanced CSS effects in favor of more basic opacity and color transitions for better performance and visual clarity. [[1]](diffhunk://#diff-3bdd5f9e87944616052f22e8443aa7bdb798fbe5f96734254e8b08f2c0a2fa0bL103) [[2]](diffhunk://#diff-3bdd5f9e87944616052f22e8443aa7bdb798fbe5f96734254e8b08f2c0a2fa0bL263-R258) [[3]](diffhunk://#diff-3bd2e6cc3614902b56e86950c5fa61fad3f2039c00f101258e9c9883abfadc58L135)

**Component-Specific Styling Tweaks:**

* Adjusted component-specific styles (such as `.stage-core`, `.question-area`, `.score-board`, `.floating-kuku`, `.warp-grid`) to use lighter shadows, reduced saturation, and more restrained color effects, especially during special states like "combo-fever" or correct/incorrect feedback. [[1]](diffhunk://#diff-3bdd5f9e87944616052f22e8443aa7bdb798fbe5f96734254e8b08f2c0a2fa0bL393-R398) [[2]](diffhunk://#diff-71bb576952a8936821b8b4e68ec1e4654587c97877cfff90496ab64ff3c6de88L100-R101) [[3]](diffhunk://#diff-3bd2e6cc3614902b56e86950c5fa61fad3f2039c00f101258e9c9883abfadc58L157-R156)
* Updated feedback and scoreboard animations to be less exaggerated, with smaller scaling and rotation, and less pronounced color effects. [[1]](diffhunk://#diff-71bb576952a8936821b8b4e68ec1e4654587c97877cfff90496ab64ff3c6de88L21-R49) [[2]](diffhunk://#diff-71bb576952a8936821b8b4e68ec1e4654587c97877cfff90496ab64ff3c6de88L147-R154)

**Documentation:**

* Updated the comment in `README.md` to clarify that `tone-engines.js` is a lightweight configuration for all platforms, not just iPhone.

These changes collectively aim to create a more polished, less visually noisy, and more performant UI experience.bug
Something isn't working